### PR TITLE
make wp server use the path config

### DIFF
--- a/command.php
+++ b/command.php
@@ -36,12 +36,10 @@ class Server_Command extends WP_CLI_Command {
 			__DIR__ . '/router.php'
 		);
 
-		$config_path = WP_CLI::get_runner()->project_config_path;
+		$docroot = WP_CLI::get_config()['path'];
 
-		if ( !$config_path ) {
+		if ( !$docroot ) {
 			$docroot = ABSPATH;
-		} else {
-			$docroot = dirname( $config_path );
 		}
 
 		$descriptors = array( STDIN, STDOUT, STDERR );


### PR DESCRIPTION
This makes it more compatible with wp-cli, and I think it fixes #3 as this is the canonical form to tell wp-cli where your worpress is.