### PR TITLE
Properly extract router.php from the Phar build

### DIFF
--- a/src/Server_Command.php
+++ b/src/Server_Command.php
@@ -78,8 +78,8 @@ class Server_Command extends WP_CLI_Command {
 		// Get the path to the router file
 		$router_path = WP_CLI_ROOT . '/vendor/wp-cli/server-command/router.php';
 		if ( ! file_exists( $router_path ) ) {
-			// server-command must've been built as the base Phar
-			$router_path = WP_CLI_ROOT . '/router.php';
+			// server command must've been built with vendor/wp-cli/wp-cli
+			$router_path = WP_CLI_ROOT . '/../../../router.php';
 			if ( ! file_exists( $router_path ) ) {
 				WP_CLI::error( "Couldn't find router.php" );
 			}

--- a/src/Server_Command.php
+++ b/src/Server_Command.php
@@ -75,12 +75,21 @@ class Server_Command extends WP_CLI_Command {
 			}
 		}
 
+		// Get the path to the router file
+		$router_path = WP_CLI_ROOT . '/vendor/wp-cli/server-command/router.php';
+		if ( ! file_exists( $router_path ) ) {
+			// server-command must've been built as the base Phar
+			$router_path = WP_CLI_ROOT . '/router.php';
+			if ( ! file_exists( $router_path ) ) {
+				WP_CLI::error( "Couldn't find router.php" );
+			}
+		}
 		$cmd = \WP_CLI\Utils\esc_cmd( '%s -S %s -t %s -c %s %s',
 			WP_CLI::get_php_binary(),
 			$assoc_args['host'] . ':' . $assoc_args['port'],
 			$docroot,
 			$assoc_args['config'],
-			dirname( dirname( __FILE__ ) ) . '/router.php'
+			\WP_CLI\Utils\extract_from_phar( $router_path )
 		);
 
 		$descriptors = array( STDIN, STDOUT, STDERR );


### PR DESCRIPTION
The file needs to be extracted because `php` calls it directly.

Fixes #13