### PR TITLE
Permit 1.x-dev as `dev-master`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         },
         "commands": [
             "server"


### PR DESCRIPTION
WP-CLI is at 1.2.0-alpha

This will fix the failing build in https://github.com/wp-cli/wp-cli/pull/3951