### PR TITLE
Fix conflict between dev-master and pull-request branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,14 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=trunk
-    - php: 5.4
+    - php: 5.3
       env: WP_VERSION=latest
 
 before_install:
   - phpenv config-rm xdebug.ini
 
 install:
+  - composer require wp-cli/wp-cli:dev-master
   - composer install
   - bash bin/install-package-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=trunk
-    - php: 5.3
+    - php: 5.4
       env: WP_VERSION=latest
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "files": [ "server-command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "dev-master"
+        "wp-cli/wp-cli": "*"
     },
     "require-dev": {
         "behat/behat": "~2.5"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -19,7 +19,7 @@ if ( file_exists( __DIR__ . '/utils.php' ) ) {
 		if ( ! empty( $composer->autoload->files ) ) {
 			$contents = 'require:' . PHP_EOL;
 			foreach( $composer->autoload->files as $file ) {
-				$contents .= '  - ' . dirname( dirname( dirname( __FILE__ ) ) ) . '/' . $file . PHP_EOL;
+				$contents .= '  - ' . dirname( dirname( dirname( __FILE__ ) ) ) . '/' . $file;
 			}
 			@mkdir( sys_get_temp_dir() . '/wp-cli-package-test/' );
 			$project_config = sys_get_temp_dir() . '/wp-cli-package-test/config.yml';
@@ -178,9 +178,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * @param array $parameters context parameters (set them up through behat.yml)
 	 */
 	public function __construct( array $parameters ) {
-		if ( getenv( 'WP_CLI_TEST_DBHOST' ) ) {
-			self::$db_settings['dbhost'] = getenv( 'WP_CLI_TEST_DBHOST' );
-		}
 		$this->drop_db();
 		$this->set_cache_dir();
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
@@ -318,8 +315,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	public function create_config( $subdir = '' ) {
 		$params = self::$db_settings;
-		// Replaces all characters that are not alphanumeric or an underscore into an underscore.
-		$params['dbprefix'] = $subdir ? preg_replace( '#[^a-zA-Z\_0-9]#', '_', $subdir ) : 'wp_';
+		$params['dbprefix'] = $subdir ?: 'wp_';
 
 		$params['skip-salts'] = true;
 		$this->proc( 'wp core config', $params, $subdir )->run_check();

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -823,16 +823,3 @@ function parse_str_to_argv( $arguments ) {
 	}, $argv );
 	return $argv;
 }
-
-/**
- * Locale-independent version of basename()
- *
- * @access public
- *
- * @param string $path
- * @param string $suffix
- * @return string
- */
-function basename( $path, $suffix = '' ) {
-	return urldecode( \basename( str_replace( array( '%2F', '%5C' ), '/', urlencode( $path ) ), $suffix ) );
-}

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -109,7 +109,7 @@ $steps->Given( '/^download:$/',
 	}
 );
 
-$steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?\s?as \{(\w+)\}$/',
+$steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?as \{(\w+)\}$/',
 	function ( $world, $stream, $output_filter, $key ) {
 
 		$stream = strtolower( $stream );

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -145,15 +145,6 @@ $steps->Then( '/^(STDOUT|STDERR) should not be empty$/',
 	}
 );
 
-$steps->Then( '/^(STDOUT|STDERR) should be a version string (<|<=|>|>=|==|=|!=|<>) ([+\w\.-]+)$/',
-	function ( $world, $stream, $operator, $goal_ver ) {
-		$stream = strtolower( $stream );
-		if ( false === version_compare( trim( $world->result->$stream, "\n" ), $goal_ver, $operator ) ) {
-			throw new Exception( $world->result );
-		}
-	}
-);	
-
 $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
 	function ( $world, $path, $type, $action, $expected = null ) {
 		$path = $world->replace_variables( $path );

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -15,7 +15,7 @@
 
 function version_tags( $prefix, $current, $operator = '<' ) {
 	if ( ! $current )
-		return array();
+		return;
 
 	exec( "grep '@{$prefix}-[0-9\.]*' -h -o features/*.feature | uniq", $existing_tags );
 


### PR DESCRIPTION
Some of the builds fail because the circular dependencies "wp-cli -> external-command -> wp-cli" produce an unresolvable conflict.
The main issue is that we had required `"wp-cli/wp-cli": "dev-master"` in the external command packages so that they can always be tested against the latest version.
However, `dev-master` only means "the latest commit on the `master` branch". So, this would then exclude other `wp-cli/wp-cli` branches to be accepted ... like for example pull requests!
Current reasoning is that we just want to make sure that we have "any" WP-CLI to work with, and define the actual version to use for the tests through Travis. So, we think that adding the following combination to each external packages `composer.json` should do the trick:
```"minimum-stability": "dev",
"prefer-stable": true,
"require": {
   "wp-cli/wp-cli": "*"
}
```
This specific combination means: "use the *highest* available *stable* version of `wp-cli/wp-cli` while allowing to fall back to `dev-master` if the stable versions don't meet the requirements".