### PR TITLE
Convert the server command help summary to use a third-person singular verb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/server-command
 =====================
 
-Launch PHP's built-in web server for this specific WordPress installation.
+Launches PHP's built-in web server for a specific WordPress installation.
 
 [![Build Status](https://travis-ci.org/wp-cli/server-command.svg?branch=master)](https://travis-ci.org/wp-cli/server-command)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/server-command",
-    "description": "Launch PHP's built-in web server for this specific WordPress installation.",
+    "description": "Launches PHP's built-in web server for a specific WordPress installation.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/server-command",
     "support": {

--- a/src/Server_Command.php
+++ b/src/Server_Command.php
@@ -3,7 +3,7 @@
 class Server_Command extends WP_CLI_Command {
 
 	/**
-	 * Launches PHP's built-in web server for this specific WordPress installation.
+	 * Launches PHP's built-in web server for a specific WordPress installation.
 	 *
 	 * Uses `php -S` to launch a web server serving the WordPress webroot.
 	 * <http://php.net/manual/en/features.commandline.webserver.php>

--- a/src/Server_Command.php
+++ b/src/Server_Command.php
@@ -3,7 +3,7 @@
 class Server_Command extends WP_CLI_Command {
 
 	/**
-	 * Launch PHP's built-in web server for this specific WordPress installation.
+	 * Launches PHP's built-in web server for this specific WordPress installation.
 	 *
 	 * Uses `php -S` to launch a web server serving the WordPress webroot.
 	 * <http://php.net/manual/en/features.commandline.webserver.php>


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for the server command to use a third-person singular verb.