### PR TITLE
Restore blogdescription to fix test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "wp-cli/wp-cli": "^2.5"
     },
     "require-dev": {
+        "wp-cli/entity-command": "^2",
         "wp-cli/wp-cli-tests": "^3.1"
     },
     "config": {

--- a/features/server.feature
+++ b/features/server.feature
@@ -4,6 +4,7 @@ Feature: Serve WordPress locally
   Scenario: Vanilla install
     Given a WP install
     And I launch in the background `wp server --host=localhost --port=8181`
+    And I run `wp option set blogdescription 'Just another WordPress site'`
 
     When I run `curl -sS localhost:8181`
     Then STDOUT should contain:


### PR DESCRIPTION
Set a `blogdescription` in tests after it was set to empty string in WordPress core https://github.com/WordPress/wordpress-develop/commit/66dba67484a2e0aaa7bcafc0fa70b33d64448f74 this fixes test failure in https://github.com/wp-cli/automated-tests/runs/7797876750?check_suite_focus=true#step:14:556