### PR TITLE
Fix docstring indent issue in feature files

### DIFF
--- a/features/server.feature
+++ b/features/server.feature
@@ -8,9 +8,9 @@ Feature: Serve WordPress locally
 
     When I run `curl -sS localhost:8181`
     Then STDOUT should contain:
-    """
-    Just another WordPress site
-    """
+      """
+      Just another WordPress site
+      """
 
     When I run `curl -sS localhost:8181/license.txt > /tmp/license.txt`
     And I run `cmp /tmp/license.txt license.txt`


### PR DESCRIPTION
Before:
```gherkin
    When I run `curl -sS localhost:8181`
    Then STDOUT should contain:
    """
    Just another WordPress site
    """
```

After:
```gherkin
    When I run `curl -sS localhost:8181`
    Then STDOUT should contain:
      """
      Just another WordPress site
      """

```

In our feature tests, we generally use indented docstring block. Majority of tests use this convention but there are some files which does not abide this.

Since there is no rules for this in `gherkin-lint`, I have developed custom rule for `gherkin-lint`. https://github.com/ernilambar/gherkin-lint-rules/blob/main/custom-rules/docstring-indent.js 
Currently I am running this locally to detect issue and working on preparing PR for WPCLI repos. We can also integrate this rule in the central repo if deemed feasible.